### PR TITLE
[Fruit Tree Tweaks] Fruit stay through seasons

### DIFF
--- a/FruitTreeTweaks/CodePatches.cs
+++ b/FruitTreeTweaks/CodePatches.cs
@@ -283,6 +283,19 @@ namespace FruitTreeTweaks
                 return;
             }
         }
+
+        [HarmonyPatch(typeof(FruitTree), nameof(FruitTree.seasonUpdate))]
+        public class FruitTree_SeasonUpdate_Patch
+        {
+            public static bool Prefix(ref bool __result, bool onLoad)
+            {
+                if (Config.EnableMod && Config.FruitStayThroughSeasons) {
+                    __result = false; // This is the original return value
+                    return false; // Do not run original code
+                }
+                return true;
+            }
+        }
         #endregion
 
         #region Placement Logic

--- a/FruitTreeTweaks/Methods.cs
+++ b/FruitTreeTweaks/Methods.cs
@@ -92,6 +92,31 @@ namespace FruitTreeTweaks
             return (!string.IsNullOrEmpty(deniedMessage) ? false : true);
         }
 
+        private static void HandleFruitStayThroughSeasonsChange()
+        {
+            // For each tree, do a season update to remove out of season fruit
+            // for the FruitStayThroughSeasons option. This should be called
+            // when the option is changed. This should be safe to call
+            // regardless of whether the option is off or on since the prefix
+            // will check
+            Utility.ForEachLocation(
+                delegate(GameLocation location)
+                {
+                    location.terrainFeatures.RemoveWhere(
+                        (KeyValuePair<Vector2, TerrainFeature> pair) =>
+                        {
+                            if (pair.Value is FruitTree fruitTree)
+                            {
+                                return fruitTree.seasonUpdate(false);
+                            }
+                            return false;
+                        }
+                    );
+                    return true;
+                }
+            );
+        }
+
         #region Draw Methods
         private static Texture2D GetTexture(FruitTree tree, out Rectangle sourceRect)
         {

--- a/FruitTreeTweaks/ModConfig.cs
+++ b/FruitTreeTweaks/ModConfig.cs
@@ -9,6 +9,7 @@
         public bool PlantAnywhere { get; set; } = false;
         public bool FruitAllSeasons { get; set; } = true;
         public bool FruitInWinter { get; set; } = false;
+        public bool FruitStayThroughSeasons { get; set; } = false;
         public int DaysUntilMature { get; set; } = 28;
         public int MaxFruitPerTree { get; set; } = 3;
         public int MinFruitPerDay { get; set; } = 1;

--- a/FruitTreeTweaks/ModEntry.cs
+++ b/FruitTreeTweaks/ModEntry.cs
@@ -1,11 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Reflection.Metadata;
-using HarmonyLib;
-using Microsoft.Xna.Framework;
+﻿using HarmonyLib;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
-using StardewValley;
-using StardewValley.TerrainFeatures;
 
 namespace FruitTreeTweaks
 {

--- a/FruitTreeTweaks/ModEntry.cs
+++ b/FruitTreeTweaks/ModEntry.cs
@@ -1,6 +1,11 @@
-﻿using HarmonyLib;
+﻿using System.Collections.Generic;
+using System.Reflection.Metadata;
+using HarmonyLib;
+using Microsoft.Xna.Framework;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
+using StardewValley;
+using StardewValley.TerrainFeatures;
 
 namespace FruitTreeTweaks
 {
@@ -88,7 +93,7 @@ namespace FruitTreeTweaks
             configMenu.Register(
                 mod: ModManifest,
                 reset: () => Config = new ModConfig(),
-                save: () => Helper.WriteConfig(Config)
+                save: () => onSave()
             );
 
             configMenu.AddSectionTitle( // Generic Options
@@ -193,6 +198,15 @@ namespace FruitTreeTweaks
             );
             Log($"Fruit In Winter: {Config.FruitInWinter}", debugOnly: true);
 
+            configMenu.AddBoolOption(
+                mod: ModManifest,
+                name: () => I18n.FruitStayThroughSeasons(),
+                tooltip: () => I18n.FruitStayThroughSeasons_1(),
+                getValue: () => Config.FruitStayThroughSeasons,
+                setValue: value => Config.FruitStayThroughSeasons = value
+            );
+            Log($"Fruit Stay Through Seasons: {Config.FruitStayThroughSeasons}", debugOnly: true);
+
             configMenu.AddNumberOption(
                 mod: ModManifest,
                 name: () => I18n.MinFruitDay(),
@@ -291,6 +305,13 @@ namespace FruitTreeTweaks
         private void GameLoop_SaveLoaded(object sender, SaveLoadedEventArgs e)
         {
             fruitToday = GetFruitPerDay(); // this breaks if it is anywhere else so dont move it
+            HandleFruitStayThroughSeasonsChange();
+        }
+
+        private void onSave()
+        {
+            Helper.WriteConfig(Config);
+            HandleFruitStayThroughSeasonsChange();
         }
     }
 }

--- a/FruitTreeTweaks/i18n/default.json
+++ b/FruitTreeTweaks/i18n/default.json
@@ -19,6 +19,8 @@
   "FruitAllSeasons.1": "Excludes Winter",
   "FruitInWinter": "Fruit In Winter",
   "FruitInWinter.1": "Expands Fruit All Seasons to include Winter. Fruit All Seasons must be enabled.",
+  "FruitStayThroughSeasons": "Fruit Stay Through Seasons",
+  "FruitStayThroughSeasons.1": "Fruits will stay on trees even out of season. This option is only relevant if Fruit All Seasons is disabled",
   "MaxFruitTree": "Max Fruit / Tree",
   "DaysUntilMature": "Days to Mature",
   "SaplingMaturity": "Use Base Sapling Maturity",


### PR DESCRIPTION
Allows fruit to stay on their trees even when they're out of season. This option is only relevant if the option for allowing fruit to keep growing when out of season is off

I didn't test this flow prior to this change, but if you select fruit all seasons -> grow out of season fruit -> unselect fruit all seasons, I'm not sure if the out of season fruit goes away. With this change, the fruit definitely goes away regardless of whether fruit stay through seasons option is touched

I didn't add translations for other languages since I don't know them, but I also don't know what happens if there isn't an entry

I wrote this for mainly myself but now the code exists so I might as well share it in case you want to include it. Is it well written or even correct? I mean it does what it claims to do with my settings but I don't know if it interferes with anything else